### PR TITLE
add editor id, support multiple json editors in same page

### DIFF
--- a/components/vue3-json-editor.tsx
+++ b/components/vue3-json-editor.tsx
@@ -94,8 +94,7 @@ export const Vue3JsonEditor = defineComponent({
     })
 
     function expandAll () {
-      console.log(state.editor.getMode())
-      if (props.expandedOnStart && state.expandedModes.includes(state.editor.getMode())) {
+      if (props.expandedOnStart && state.expandedModes.includes(props.mode) {
         (state.editor as any).expandAll()
       }
     }

--- a/components/vue3-json-editor.tsx
+++ b/components/vue3-json-editor.tsx
@@ -24,6 +24,10 @@ export const Vue3JsonEditor = defineComponent({
     lang: {
       type: String,
       default: 'en'
+    },
+    editorId: {
+      type: String,
+      default: 'jsoneditor-vue'
     }
   },
   setup (props: any, { emit }) {
@@ -83,7 +87,7 @@ export const Vue3JsonEditor = defineComponent({
         }
       }
       state.editor = new JsonEditor(
-        document.querySelector('.jsoneditor-vue'),
+        document.querySelector("#" + props.editorId),
         options,
         state.json
       )
@@ -107,7 +111,7 @@ export const Vue3JsonEditor = defineComponent({
     return () => {
       return (
         <div>
-          <div class={'jsoneditor-vue'}></div>
+          <div id={props.editorId} class={'jsoneditor-vue'}></div>
           {props.showBtns !== false && (
             <div class={'jsoneditor-btns'}>
               <button

--- a/components/vue3-json-editor.tsx
+++ b/components/vue3-json-editor.tsx
@@ -102,7 +102,7 @@ export const Vue3JsonEditor = defineComponent({
     })
 
     function expandAll () {
-      if (props.expandedOnStart && state.expandedModes.includes(props.mode) {
+      if (props.expandedOnStart && state.expandedModes.includes(props.mode)) {
         (state.editor as any).expandAll()
       }
     }

--- a/components/vue3-json-editor.tsx
+++ b/components/vue3-json-editor.tsx
@@ -27,7 +27,15 @@ export const Vue3JsonEditor = defineComponent({
     },
     editorId: {
       type: String,
-      default: 'jsoneditor-vue'
+      default: function () {
+        let d = new Date().getTime()
+        let uuid = 'xxxxxxxx-xxxx-xxxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+            var r = (d + Math.random() * 16) % 16 | 0
+            d = Math.floor(d / 16)
+            return (c == 'x' ? r : (r & 0x3 | 0x8)).toString(16)
+        })
+        return ('jsoneditor-vue-' + uuid)
+      }
     }
   },
   setup (props: any, { emit }) {


### PR DESCRIPTION
```
<template>
  <Vue3JsonEditor editor-id="json-editor-a" v-model="model"/>
  <Vue3JsonEditor editor-id="json-editor-b" v-model="model"/>
</template>
...
```

![image](https://user-images.githubusercontent.com/1424959/145743866-f18795f7-9c73-4199-b01c-40615c38ac43.png)

