### PR TITLE
fix: Example Change data binding to bidirectional

### DIFF
--- a/components/vue3-json-editor.tsx
+++ b/components/vue3-json-editor.tsx
@@ -71,7 +71,7 @@ export const Vue3JsonEditor = defineComponent({
             state.error = false
             emit('json-change', json)
             state.internalChange = true
-            emit('input', json)
+            emit('update:modelValue', json)
             root.$nextTick(function () {
               state.internalChange = false
             })


### PR DESCRIPTION
For bidirectional binding events, `update:modelValue` should be used instead of `input`